### PR TITLE
Ks/default packed for proto2

### DIFF
--- a/test/protobuf/decoder_test.exs
+++ b/test/protobuf/decoder_test.exs
@@ -117,6 +117,42 @@ defmodule Protobuf.DecoderTest do
              TestMsg.Foo2.new(a: 0, l: %{})
   end
 
+  test "decodes packed binary using RepeatedUnPacked for proto2" do
+    packed = <<10, 5, 1, 2, 3, 4, 5>>
+
+    struct = Decoder.decode(packed, TestMsg.RepeatedUnPacked)
+
+    assert %TestMsg.RepeatedUnPacked{} = struct
+    assert struct.a == [1, 2, 3, 4, 5]
+  end
+
+  test "decodes unpacked binary using RepeatedUnPacked for proto2" do
+    unpacked = <<8, 1, 8, 2, 8, 3, 8, 4, 8, 5>>
+
+    struct = Decoder.decode(unpacked, TestMsg.RepeatedUnPacked)
+
+    assert %TestMsg.RepeatedUnPacked{} = struct
+    assert struct.a == [1, 2, 3, 4, 5]
+  end
+
+  test "decodes packed binary using RepeatedPacked for proto2" do
+    packed = <<10, 5, 1, 2, 3, 4, 5>>
+
+    struct = Decoder.decode(packed, TestMsg.RepeatedPacked)
+
+    assert %TestMsg.RepeatedPacked{} = struct
+    assert struct.a == [1, 2, 3, 4, 5]
+  end
+
+  test "decodes unpacked binary using RepeatedPacked for proto2" do
+    unpacked = <<8, 1, 8, 2, 8, 3, 8, 4, 8, 5>>
+
+    struct = Decoder.decode(unpacked, TestMsg.RepeatedPacked)
+
+    assert %TestMsg.RepeatedPacked{} = struct
+    assert struct.a == [1, 2, 3, 4, 5]
+  end
+
   test "decodes custom default message for proto2" do
     assert Decoder.decode(<<8, 0, 17, 0, 0, 0, 0, 0, 0, 0, 0>>, TestMsg.Foo2) ==
              TestMsg.Foo2.new(a: 0, b: 0)

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -87,6 +87,24 @@ defmodule TestMsg do
     field :non_matched, 101, type: :int32, optional: true
   end
 
+  defmodule RepeatedPacked do
+    @moduledoc false
+    use Protobuf, syntax: :proto2
+
+    defstruct [:a]
+
+    field :a, 1, repeated: true, type: :uint32, packed: true
+  end
+
+  defmodule RepeatedUnPacked do
+    @moduledoc false
+    use Protobuf, syntax: :proto2
+
+    defstruct [:a]
+
+    field :a, 1, repeated: true, type: :uint32
+  end
+
   defmodule Oneof do
     @moduledoc false
     use Protobuf


### PR DESCRIPTION
> From the docs: (https://developers.google.com/protocol-buffers/docs/encoding#packed)
> 
> Protocol buffer parsers must be able to parse repeated fields that
> were compiled as packed as if they were not packed, and vice versa.
> This permits adding [packed=true] to existing fields in a forward- and
> backward-compatible way.

Currently the Decoder does not support decoding a binary where the field
has been packed, but the module defines a field which has not been
tagged with the [packed=true] option. In that case the "wrong wire_type
for #{field}" error is shown. This behaviour does not conform with the
recommendation from the docs (as shown above).

Therefore this commit updates the Decoder to support both packed and
unpacked binaries for proto2, using a module where the packed=true
option has been set, and one where it has not been set.

Note: For proto3 this is a non issue, because the default behaviour is packed.