### PR TITLE
Update Decoder: use Wire.to_proto for varints

### DIFF
--- a/lib/protobuf/decoder.ex
+++ b/lib/protobuf/decoder.ex
@@ -203,16 +203,16 @@ defmodule Protobuf.Decoder do
     acc = current || []
 
     case prop.wire_type do
-      wire_varint() -> decode_varints(bin, acc)
+      wire_varint() -> decode_varints(bin, prop.type, acc)
       wire_32bits() -> decode_fixed32(bin, prop.type, acc)
       wire_64bits() -> decode_fixed64(bin, prop.type, acc)
     end
   end
 
-  defp decode_varints(<<>>, acc), do: acc
+  defp decode_varints(<<>>, _, acc), do: acc
 
-  decoder :defp, :decode_varints, [:acc] do
-    decode_varints(rest, [value | acc])
+  decoder :defp, :decode_varints, [:type, :acc] do
+    decode_varints(rest, type, [Wire.to_proto(type, value) | acc])
   end
 
   defp decode_fixed32(<<n::bits-32, bin::bits>>, type, acc) do

--- a/test/protobuf/decoder_test.exs
+++ b/test/protobuf/decoder_test.exs
@@ -117,6 +117,24 @@ defmodule Protobuf.DecoderTest do
              TestMsg.Foo2.new(a: 0, l: %{})
   end
 
+  test "decodes unpacked binary with SignedInt32Repeated for proto2" do
+    unpacked = <<8, 1, 8, 2, 8, 3, 8, 4, 8, 5>>
+
+    struct = Decoder.decode(unpacked, TestMsg.SignedInt32Repeated)
+
+    assert %TestMsg.SignedInt32Repeated{} = struct
+    assert struct.a == [-1, 1, -2, 2, -3]
+  end
+
+  test "decodes packed binary with SignedInt32RepeatedPacked for proto2" do
+    packed = <<10, 5, 1, 2, 3, 4, 5>>
+
+    struct = Decoder.decode(packed, TestMsg.SignedInt32RepeatedPacked)
+
+    assert %TestMsg.SignedInt32RepeatedPacked{} = struct
+    assert struct.a == [-1, 1, -2, 2, -3]
+  end
+
   test "decodes packed binary using RepeatedUnPacked for proto2" do
     packed = <<10, 5, 1, 2, 3, 4, 5>>
 

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -87,6 +87,24 @@ defmodule TestMsg do
     field :non_matched, 101, type: :int32, optional: true
   end
 
+  defmodule SignedInt32Repeated do
+    @moduledoc false
+    use Protobuf, syntax: :proto2
+
+    defstruct [:a]
+
+    field :a, 1, repeated: true, type: :sint32
+  end
+
+  defmodule SignedInt32RepeatedPacked do
+    @moduledoc false
+    use Protobuf, syntax: :proto2
+
+    defstruct [:a]
+
+    field :a, 1, repeated: true, type: :sint32, packed: true
+  end
+
   defmodule RepeatedPacked do
     @moduledoc false
     use Protobuf, syntax: :proto2


### PR DESCRIPTION
When decoding repeated varint values, the value was not converted from
wire format to protobuf format, and consequently any signed integers
which are encoded using ZigZag format were incorrect. This commit
updates the `decode_varints/2` function to `decode_varints/3` which
includes the type and enables conversion to protobuf format.